### PR TITLE
fix: use block release validation command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
             "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
           chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
       - name: Validate plugin contract for publish (pre-build)
-        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" ."
+        run: |
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
Follow-up for GoCodeAlone/workflow#760.

Fixes the release workflow YAML quoting introduced while hardening tag handling:
- converts the pre-build validate-contract command to a block run step
- keeps the shell-level quotes around github.ref_name

Verification:
- git diff --check
